### PR TITLE
Update DESCRIPTION

### DIFF
--- a/JAMP/DESCRIPTION
+++ b/JAMP/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: JAMP
 Type: Package
 Title: Just Another Metabarcoding Pipeline
-Version: 0.67
-Date: 2018-12-22
+Version: 0.77
+Date: 2020-04-01
 Author: Vasco Elbrecht
 Maintainer: Vasco Elbrecht <luckylion07@googlemail.com>
 Description: Modular pipeline to process metabarcoding Illumina data. Optimised for fusion primer systems (in line barcodes), with frame shifting tags (see Elbrecht & Leese 2015, PlosONE). Still working on documentation, for support write @VascoElbrecht.


### PR DESCRIPTION
I think this way RStudio will display the correct version number. I was just wondering why I have 0.67 even after installing 0.77 :-) The same for PrimerMiner. It might happen that someone mentions incorrect number in their publication. It might matter now that vsearch was enabled.